### PR TITLE
flake: use upstream scion again

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,15 +77,15 @@
     "scion-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1645414291,
+        "lastModified": 1645440591,
         "narHash": "sha256-ZJYXdv2jNdgIOTjAJX3siAlUXnoSqnydZDW5wEezt3c=",
-        "owner": "matthewcroughan",
+        "owner": "netsec-ethz",
         "repo": "scion",
-        "rev": "148a3da4bcdb508fce774c7b87bf1b680888e2a5",
+        "rev": "1589a47f8c79cf43d13e86cefc16ac9ea8694ab5",
         "type": "github"
       },
       "original": {
-        "owner": "matthewcroughan",
+        "owner": "netsec-ethz",
         "ref": "scionlab",
         "repo": "scion",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -5,11 +5,7 @@
   inputs.nixpkgs = { type = "github"; owner = "NixOS"; repo = "nixpkgs"; ref = "nixos-unstable"; };
 
   # Upstream source tree(s).
-  #inputs.scion-src = { type = "github"; owner = "netsec-ethz"; repo = "scion"; ref = "scionlab"; flake = false; };
-
-  # scion are not commiting their go.mod/go.sum properly, so using our own fork
-  # for now.
-  inputs.scion-src = { url = "github:matthewcroughan/scion/scionlab"; flake = false; };
+  inputs.scion-src = { type = "github"; owner = "netsec-ethz"; repo = "scion"; ref = "scionlab"; flake = false; };
 
   inputs.scion-apps-src = { type = "github"; owner = "netsec-ethz"; repo = "scion-apps"; flake = false; };
   inputs.scionlab-src = { type = "github"; owner = "netsec-ethz"; repo = "scionlab"; ref = "develop"; flake = false; };


### PR DESCRIPTION
The lockfile is now correctly available upstream.